### PR TITLE
Fix: make controller multitouch supported

### DIFF
--- a/src/controllers/controller.ts
+++ b/src/controllers/controller.ts
@@ -148,7 +148,7 @@ export class Controller {
         if (
             !this.elEventStarter.hasPointerCapture(evt.pointerId) ||
             !this.state.isPressed ||
-            this.state.pointerId < 0
+            this.state.pointerId !== evt.pointerId
         ) {
             return;
         }
@@ -180,7 +180,7 @@ export class Controller {
 
     handleEnd(evt: PointerEvent) {
         // If touch was not registered on touch-start - do nothing
-        if (this.state.pointerId < 0) {
+        if (this.state.pointerId !== evt.pointerId) {
             return;
         }
 


### PR DESCRIPTION
Multitouch support fix.

To test the bug before this PR, using a joystick and a button on a smartphone : improper behavior while maintaining one finger on each controller (try move them, or raise up one of them, the other controller stops or is moved by the other)